### PR TITLE
fix MemberExpression,NewExpression in key,value

### DIFF
--- a/transforms/__testfixtures__/remove-test-selector-helper.input.js
+++ b/transforms/__testfixtures__/remove-test-selector-helper.input.js
@@ -26,6 +26,21 @@ let selectors = {
   a: 'a',
 };
 
+// MemberExpressions for key and value
 testSelector(selectors.a);
+testSelector('key', selectors.a);
+testSelector(selectors.a, 'value');
+testSelector(selectors.a, selectors.a);
+testSelector(this.a);
+testSelector('key', this.a);
+testSelector(this.a, 'value');
+testSelector(this.a, this.a);
 
+// NewExpression
+testSelector(new A());
+testSelector(new A(), 'value');
+testSelector('key', new A());
+testSelector(new A(), new A());
+
+// value: UnaryExpression
 testSelector('key', -1);

--- a/transforms/__testfixtures__/remove-test-selector-helper.output.js
+++ b/transforms/__testfixtures__/remove-test-selector-helper.output.js
@@ -24,6 +24,21 @@ let selectors = {
   a: 'a',
 };
 
+// MemberExpressions for key and value
 `[data-test-${selectors.a}]`;
+`[data-test-key="${selectors.a}"]`;
+`[data-test-${selectors.a}="value"]`;
+`[data-test-${selectors.a}="${selectors.a}"]`;
+`[data-test-${this.a}]`;
+`[data-test-key="${this.a}"]`;
+`[data-test-${this.a}="value"]`;
+`[data-test-${this.a}="${this.a}"]`;
 
+// NewExpression
+`[data-test-${new A()}]`;
+`[data-test-${new A()}="value"]`;
+`[data-test-key="${new A()}"]`;
+`[data-test-${new A()}="${new A()}"]`;
+
+// value: UnaryExpression
 '[data-test-key="-1"]';

--- a/transforms/remove-test-selector-helper.js
+++ b/transforms/remove-test-selector-helper.js
@@ -14,8 +14,7 @@ module.exports = (file, api, options) => {
         if (node.arguments.length === 1) {
           if (key.type === 'Literal') {
             return j.literal(`[data-test-${key.value}]`);
-          } else if (key.type === 'Identifier' ||
-            key.type === 'MemberExpression') {
+          } else {
             let first = '[data-test-';
             let second = ']';
             let quasis = [j.templateElement({cooked: first, raw: first}, false), j.templateElement({cooked: second, raw: second}, true)];
@@ -28,19 +27,19 @@ module.exports = (file, api, options) => {
           } else if (key.type === 'Literal' && value.type === 'UnaryExpression' &&
             value.argument.type === 'Literal') {
             return j.literal(`[data-test-${key.value}="${value.operator}${value.argument.value}"]`);
-          } else if (key.type === 'Literal' && (value.type === 'Identifier' || value.type === 'CallExpression')) {
+          } else if (key.type === 'Literal' && value.type !== 'Literal') {
             let first = `[data-test-${key.value}="`;
             let second = '"]';
             let quasis = [j.templateElement({cooked: first, raw: first}, false), j.templateElement({cooked: second, raw: second}, true)];
             return j.templateLiteral(quasis, [value]);
-          } else if (key.type === 'Identifier' && value.type === 'Literal') {
+          } else if (key.type !== 'Literal' && value.type === 'Literal') {
             let first = '[data-test-';
             let second = `="${value.value}"]`;
             let quasis = [
               j.templateElement({cooked: first, raw: first}, false),
               j.templateElement({cooked: second, raw: second}, true)];
             return j.templateLiteral(quasis, [key]);
-          } else if (key.type === 'Identifier' && value.type === 'Identifier') {
+          } else if (key.type !== 'Literal' && value.type !== 'Literal') {
             let first = '[data-test-';
             let second = '="';
             let third = '"]';


### PR DESCRIPTION
I noticed that MemberExpressions weren't handled for values (e.g. `testSelector("str", a.foo)`) when I ran this against my app.

I also took a moment to refactor the transform to handle more cases. This might be overly broad, but the conditional is a bit more exhaustive now, breaking down along Literal vs !Literal. I left in the explicit handling of UnaryExpression.

Thanks for making this transform!